### PR TITLE
Return section and pub date

### DIFF
--- a/internal/get_content_analysis.go
+++ b/internal/get_content_analysis.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ConstructContentAnalysis(path string, articleFields *models.ArticleFields, entities []*comprehend.Entity, cacheHit bool) *models.ContentAnalysis {
+func ConstructContentAnalysis(path string, content *models.Content, entities []*comprehend.Entity, cacheHit bool) *models.ContentAnalysis {
 	byline := models.Byline{
-		Name: articleFields.Byline,
+		Name: content.Fields.Byline,
 	}
 
 	var people []*models.Person = nil
@@ -43,8 +43,8 @@ func ConstructContentAnalysis(path string, articleFields *models.ArticleFields, 
 
 	contentAnalysis := models.ContentAnalysis{
 		Path:               path,
-		Headline:           articleFields.Headline,
-		BodyText:           articleFields.BodyText,
+		Headline:           content.Fields.Headline,
+		BodyText:           content.Fields.BodyText,
 		Bylines:            []*models.Byline{&byline},
 		People:             people,
 		Locations:          locations,

--- a/internal/get_content_analysis.go
+++ b/internal/get_content_analysis.go
@@ -53,6 +53,8 @@ func ConstructContentAnalysis(path string, content *models.Content, entities []*
 		CommercialItems:    commercialItems,
 		Events:             events,
 		CacheHit:           cacheHit,
+		Section:            content.Section,
+		WebPublicationDate: content.WebPublicationDate,
 	}
 
 	return &contentAnalysis

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -2,40 +2,46 @@ package models
 
 import "github.com/aws/aws-sdk-go/service/comprehend"
 
-type ArticleFields struct {
-	Headline string `json:"headline"`
-	Byline   string `json:"byline"`
-	BodyText string `json:"bodyText"`
+type ContentFields struct {
+    Headline string `json:"headline"`
+    Byline   string `json:"byline"`
+    BodyText string `json:"bodyText"`
 }
-
+type Content struct {
+    WebPublicationDate string `json:"webPublicationDate"`
+    Section            string `json:"sectionId"`
+    Fields             ContentFields `json:"fields"`
+}
 type Gender int
 
 const (
-	Unknown Gender = 0
-	Female  Gender = 1
-	Male    Gender = 2
+    Unknown Gender = 0
+    Female  Gender = 1
+    Male    Gender = 2
 )
 
 type Byline struct {
-	Name   string `json:"name"`
-	Gender Gender `json:"gender"`
+    Name   string `json:"name"`
+    Gender Gender `json:"gender"`
 }
 
 type Person struct {
-	comprehend.Entity
-	Gender Gender
+    comprehend.Entity
+    Gender Gender
 }
 
 type ContentAnalysis struct {
-	Path               string               `json:"path"`
-	Headline           string               `json:"headline"`
-	BodyText           string               `json:"bodyText"`
-	Bylines            []*Byline            `json:"bylines"`
-	People             []*Person            `json:"people"`
-	Locations          []*comprehend.Entity `json:"locations"`
-	Organisations      []*comprehend.Entity `json:"organisations"`
-	CreativeWorkTitles []*comprehend.Entity `json:"creativeWorkTitles"`
-	CommercialItems    []*comprehend.Entity `json:"commercialItems"`
-	Events             []*comprehend.Entity `json:"events"`
-	CacheHit           bool                 `json:"cacheHit"`
+    Path               string               `json:"path"`
+    Headline           string               `json:"headline"`
+    BodyText           string               `json:"bodyText"`
+    Bylines            []*Byline            `json:"bylines"`
+    People             []*Person            `json:"people"`
+    Locations          []*comprehend.Entity `json:"locations"`
+    Organisations      []*comprehend.Entity `json:"organisations"`
+    CreativeWorkTitles []*comprehend.Entity `json:"creativeWorkTitles"`
+    CommercialItems    []*comprehend.Entity `json:"commercialItems"`
+    Events             []*comprehend.Entity `json:"events"`
+    CacheHit           bool                 `json:"cacheHit"`
+    WebPublicationDate string               `json:"webPublicationDate"`
+    Section            string               `json:"section"`
 }

--- a/internal/services/capi.go
+++ b/internal/services/capi.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 )
 
-func GetArticleFieldsFromCapi(path string, apiKey string) (*models.ArticleFields, error) {
-	var articleFields = new(models.ArticleFields)
+func GetArticleFieldsFromCapi(path string, apiKey string) (*models.Content, error) {
+	var articleFields = new(models.Content)
 	urlPrefix := "https://content.guardianapis.com"
 	urlSuffix := "?api-key=" + apiKey + "&show-fields=byline,bodyText,headline"
 	url := urlPrefix + path + urlSuffix
@@ -25,7 +25,7 @@ func GetArticleFieldsFromCapi(path string, apiKey string) (*models.ArticleFields
 	}
 
 	//TODO: validate response
-	fields := gjson.Get(string(body), "response.content.fields").Raw
+	fields := gjson.Get(string(body), "response.content").Raw
 	fieldsBytes := []byte(fields)
 	articleFieldsError := json.Unmarshal(fieldsBytes, &articleFields)
 	if articleFieldsError != nil {

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -38,7 +38,7 @@ func GetEntitiesFromPath(path string) ([]*comprehend.Entity, error) {
 		return nil, errors.Wrap(err, "Couldn't get article fields from CAPI for given path")
 	}
 
-	entities, err := GetEntitiesFromBodyText(articleFields.BodyText)
+	entities, err := GetEntitiesFromBodyText(articleFields.Fields.BodyText)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Error retrieving entities from body text")

--- a/internal/services/s3_test.go
+++ b/internal/services/s3_test.go
@@ -19,12 +19,14 @@ func TestGetContentAnalysisFromS3(t *testing.T) {
 }
 
 func TestStoreContentAnalysisInS3(t *testing.T) {
-	articleFields := models.ArticleFields{"test_headline", "test_byline", "test_body"}
+	contentFields := models.ContentFields{"test_headline", "test_byline", "test_body"}
+	content := models.Content{ "2019-01-01", "football", contentFields}
 	var events []*comprehend.Entity = nil
 	contentAnalysis := internal.ConstructContentAnalysis(
 		"/commentisfree/2019/apr/08/wall-street-socialism-jpmorgan-jamie-dimon-bailout",
-		&articleFields,
+		&content,
 		events,
+		false,
 	)
 
 	err := services.StoreContentAnalysisInS3(contentAnalysis)


### PR DESCRIPTION
these fields are one level above in the capi response model, so for convenience I've changed how we model this internally